### PR TITLE
Use bank tx ID's for import ID

### DIFF
--- a/app/controllers/monzo_controller.rb
+++ b/app/controllers/monzo_controller.rb
@@ -30,6 +30,7 @@ class MonzoController < ApplicationController
     end
 
     ynab_creator = YNAB::TransactionCreator.new(
+      id: "MONZO:" + webhook[:data][:id],
       date: Time.parse(webhook[:data][:created]).to_date,
       amount: webhook[:data][:amount] * 10,
       payee_name: payee_name,

--- a/app/controllers/starling_controller.rb
+++ b/app/controllers/starling_controller.rb
@@ -43,6 +43,7 @@ class StarlingController < ApplicationController
     end
 
     ynab_creator = YNAB::TransactionCreator.new(
+      id: "STARLING:" + webhook[:eventUid],
       date: Time.parse(webhook[:timestamp]).to_date,
       amount: amount,
       payee_name: payee_name,

--- a/app/services/import/monzo.rb
+++ b/app/services/import/monzo.rb
@@ -36,6 +36,7 @@ class Import::Monzo
       end
 
       transactions_to_create << {
+        id: "MONZO:" + transaction[:id],
         amount: transaction[:amount] * 10,
         payee_name: payee_name,
         date: Time.parse(transaction[:created]).to_date,

--- a/app/services/import/starling.rb
+++ b/app/services/import/starling.rb
@@ -10,6 +10,7 @@ class Import::Starling
     transactions_to_create = []
     @starling.transactions.list(params: { from: from, to: Date.today }).each do |transaction|
       transactions_to_create << {
+        id: "STARLING:" + transaction.eventUid,
         amount: (transaction.amount * 1000).to_i,
         payee_name: transaction.narrative.strip,
         date: transaction.created,

--- a/app/services/import/teller.rb
+++ b/app/services/import/teller.rb
@@ -12,6 +12,7 @@ class Import::Teller
     transactions_to_create = []
     transactions.select{|t| Date.parse(t[:date]) <= Date.today }.each do |transaction|
       transactions_to_create << {
+        id: "TELLER:" + transaction[:id],
         amount: (transaction[:amount].to_f * 1000).to_i,
         payee_name: transaction[:counterparty],
         date: Date.parse(transaction[:date]),

--- a/app/services/ynab/bulk_transaction_creator.rb
+++ b/app/services/ynab/bulk_transaction_creator.rb
@@ -26,7 +26,7 @@ class YNAB::BulkTransactionCreator
       transactions.each do |transaction|
 
         transactions_to_create << {
-          import_id: @import_id_creator.import_id(transaction[:amount], transaction[:date].to_date),
+          import_id: transaction[:id] || @import_id_creator.import_id(transaction[:amount], transaction[:date].to_date),
           account_id: @client.selected_account_id,
           payee_name: transaction[:payee_name],
           amount: transaction[:amount],

--- a/app/services/ynab/transaction_creator.rb
+++ b/app/services/ynab/transaction_creator.rb
@@ -17,7 +17,7 @@ class YNAB::TransactionCreator
     @import_id_creator.prefill!(@client, @date.to_date)
 
     create = @client.create_transaction(
-      id: @import_id_creator.import_id(@amount, @date.to_date),
+      id: @id || @import_id_creator.import_id(@amount, @date.to_date),
       payee_name: @payee_name,
       amount: @amount,
       cleared: @cleared,


### PR DESCRIPTION
Use the tx ID's provided by each bank for the import ID. This should prevent duplicate tx's from being created.